### PR TITLE
Only call write_attribute if the thing being assigned is actually an attribute

### DIFF
--- a/lib/enumerated_attribute/integrations/active_record.rb
+++ b/lib/enumerated_attribute/integrations/active_record.rb
@@ -21,7 +21,13 @@ module EnumeratedAttribute
 
 			def write_enumerated_attribute(name, val)
 				name = name.to_s
-				return write_attribute(name, val) unless self.class.has_enumerated_attribute?(name)
+				if !self.class.has_enumerated_attribute?(name)
+					result = val
+					# only call write_attribute if the name is actually an attribute
+					# if the name is a relation, it's handled elsewhere
+					result = write_attribute(name, val) if has_attribute?(name)
+					return result
+				end
 				val = nil if val == ''
 				val_str = val.to_s if val
 				val_sym = val.to_sym if val


### PR DESCRIPTION
This avoids deprecation warnings from ActiveRecord complaining about creating attributes when passing initial values to `create` for relations for ActiveRecord models that use enumerated attributes.

Example:

    class Foo < ActiveRecord::Base
        attr_accessible :bar, :state
        has_one :bar
        enum_attr :state, %w(baz quux)
    end

    # triggers deprecation warning without this PR
    Foo.create(bar: Bar.create) 

Relations are handled by ActiveRecord along a different code path. Usually, the actual attribute to be assigned ends in `_id`. The code being avoided this way had no effect.